### PR TITLE
WIP - Don't delete the db on every restart.

### DIFF
--- a/cmd/tellor/main.go
+++ b/cmd/tellor/main.go
@@ -92,7 +92,6 @@ func buildContext() error {
 func AddDBToCtx(remote bool) error {
 	cfg := config.GetConfig()
 	// Create a db instance
-	os.RemoveAll(cfg.DBFile)
 	DB, err := db.Open(cfg.DBFile)
 	if err != nil {
 		return err


### PR DESCRIPTION
closes: https://github.com/tellor-io/TellorMiner/issues/227
This looks like some mistake in the early stages of the project. Or because of some subtle bug the couldn't be solved at the time.

My suggestion is to keep the db between restarts is this is crucial for keeping track of the transaction cost and if we notice any problems can fix those in follow up PRs.