### PR TITLE
Removing the usafe of global context

### DIFF
--- a/cmd/tellor/main.go
+++ b/cmd/tellor/main.go
@@ -156,7 +156,7 @@ func App() *cli.Cli {
 	app.Command("stake", "staking operations", stakeCmd(logSetup, logLevel))
 	app.Command("transfer", "send TRB to address", moveCmd(ops.Transfer, logSetup, logLevel))
 	app.Command("approve", "approve TRB to address", moveCmd(ops.Approve, logSetup, logLevel))
-	//Using values from context, until we have a function that setups the client and returns as values, not as part of the context
+	// Using values from context, until we have a function that setups the client and returns as values, not as part of the context
 	app.Command("balance", "check balance of address", balanceCmd(ctx.Value(tellorCommon.ClientContextKey).(rpc.ETHClient), ctx.Value(tellorCommon.ContractsGetterContextKey).(*getter.TellorGetters), ctx.Value(tellorCommon.PublicAddress).(common.Address)))
 	app.Command("dispute", "dispute operations", disputeCmd(logSetup, logLevel))
 	app.Command("mine", "mine for TRB", mineCmd(logSetup, logLevel))

--- a/cmd/tellor/main.go
+++ b/cmd/tellor/main.go
@@ -156,7 +156,8 @@ func App() *cli.Cli {
 	app.Command("stake", "staking operations", stakeCmd(logSetup, logLevel))
 	app.Command("transfer", "send TRB to address", moveCmd(ops.Transfer, logSetup, logLevel))
 	app.Command("approve", "approve TRB to address", moveCmd(ops.Approve, logSetup, logLevel))
-	app.Command("balance", "check balance of address", balanceCmd)
+	//Using values from context, until we have a function that setups the client and returns as values, not as part of the context
+	app.Command("balance", "check balance of address", balanceCmd(ctx.Value(tellorCommon.ClientContextKey).(rpc.ETHClient), ctx.Value(tellorCommon.ContractsGetterContextKey).(*getter.TellorGetters)))
 	app.Command("dispute", "dispute operations", disputeCmd(logSetup, logLevel))
 	app.Command("mine", "mine for TRB", mineCmd(logSetup, logLevel))
 	app.Command("dataserver", "start an independent dataserver", dataserverCmd(logSetup, logLevel))

--- a/cmd/tellor/main.go
+++ b/cmd/tellor/main.go
@@ -157,7 +157,7 @@ func App() *cli.Cli {
 	app.Command("transfer", "send TRB to address", moveCmd(ops.Transfer, logSetup, logLevel))
 	app.Command("approve", "approve TRB to address", moveCmd(ops.Approve, logSetup, logLevel))
 	//Using values from context, until we have a function that setups the client and returns as values, not as part of the context
-	app.Command("balance", "check balance of address", balanceCmd(ctx.Value(tellorCommon.ClientContextKey).(rpc.ETHClient), ctx.Value(tellorCommon.ContractsGetterContextKey).(*getter.TellorGetters)))
+	app.Command("balance", "check balance of address", balanceCmd(ctx.Value(tellorCommon.ClientContextKey).(rpc.ETHClient), ctx.Value(tellorCommon.ContractsGetterContextKey).(*getter.TellorGetters), ctx.Value(tellorCommon.PublicAddress).(common.Address)))
 	app.Command("dispute", "dispute operations", disputeCmd(logSetup, logLevel))
 	app.Command("mine", "mine for TRB", mineCmd(logSetup, logLevel))
 	app.Command("dataserver", "start an independent dataserver", dataserverCmd(logSetup, logLevel))

--- a/cmd/tellor/main.go
+++ b/cmd/tellor/main.go
@@ -64,7 +64,7 @@ func setup() error {
 		if err != nil {
 			return errors.Wrap(err, "create tellor transactor instance")
 		}
-		// Leaving those in because are still used in some places(miner submission mostly)
+		// Leaving those in because are still used in some places(miner submission mostly).
 		ctx = context.WithValue(context.Background(), tellorCommon.ClientContextKey, client)
 		ctx = context.WithValue(ctx, tellorCommon.ContractAddress, contractAddress)
 		ctx = context.WithValue(ctx, tellorCommon.ContractsTellorContextKey, contractTellorInstance)
@@ -181,7 +181,14 @@ func stakeCmd(logSetup func(string) log.Logger, logLevel *string) func(*cli.Cmd)
 	}
 }
 
-func simpleCmd(f func(context.Context, log.Logger, rpc.ETHClient, tellorCommon.Contract, tellorCommon.Account) error, logSetup func(string) log.Logger, logLevel *string) func(*cli.Cmd) {
+func simpleCmd(
+	f func(context.Context,
+		log.Logger,
+		rpc.ETHClient,
+		tellorCommon.Contract,
+		tellorCommon.Account) error,
+	logSetup func(string) log.Logger,
+	logLevel *string) func(*cli.Cmd) {
 	return func(cmd *cli.Cmd) {
 		cmd.Action = func() {
 			ExitOnError(f(ctx, logSetup(*logLevel), clt, cont, acc), "")
@@ -189,7 +196,16 @@ func simpleCmd(f func(context.Context, log.Logger, rpc.ETHClient, tellorCommon.C
 	}
 }
 
-func moveCmd(f func(context.Context, log.Logger, rpc.ETHClient, tellorCommon.Contract, tellorCommon.Account, common.Address, *big.Int) error, logSetup func(string) log.Logger, logLevel *string) func(*cli.Cmd) {
+func moveCmd(
+	f func(context.Context,
+		log.Logger,
+		rpc.ETHClient,
+		tellorCommon.Contract,
+		tellorCommon.Account,
+		common.Address,
+		*big.Int) error,
+	logSetup func(string) log.Logger,
+	logLevel *string) func(*cli.Cmd) {
 	return func(cmd *cli.Cmd) {
 		amt := TRBAmount{}
 		addr := ETHAddress{}

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Tellor Authors.
+// Licensed under the MIT License.
+
 package common
 
 import (

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -1,0 +1,20 @@
+package common
+
+import (
+	"crypto/ecdsa"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/tellor-io/TellorMiner/pkg/contracts/getter"
+	"github.com/tellor-io/TellorMiner/pkg/contracts/tellor"
+)
+
+type Contract struct {
+	Getter  *getter.TellorGetters
+	Caller  *tellor.Tellor
+	Address common.Address
+}
+
+type Account struct {
+	Address    common.Address
+	PrivateKey *ecdsa.PrivateKey
+}

--- a/pkg/ops/transferOps.go
+++ b/pkg/ops/transferOps.go
@@ -23,7 +23,7 @@ import (
  * This is the operational transfer component. Its purpose is to transfer tellor tokens
  */
 
-func prepareTransfer(ctx context.Context, instance *getter.TellorGetters, account tellorCommon.Account, amt *big.Int) (*bind.TransactOpts, error) {
+func prepareTransfer(ctx context.Context, client rpc.ETHClient, instance *getter.TellorGetters, account tellorCommon.Account, amt *big.Int) (*bind.TransactOpts, error) {
 	balance, err := instance.BalanceOf(nil, account.Address)
 	if err != nil {
 		return nil, errors.Wrap(err, "get balance")
@@ -34,15 +34,15 @@ func prepareTransfer(ctx context.Context, instance *getter.TellorGetters, accoun
 			util.FormatERC20Balance(balance),
 			util.FormatERC20Balance(amt))
 	}
-	auth, err := PrepareEthTransaction(ctx)
+	auth, err := PrepareEthTransaction(ctx, client, account)
 	if err != nil {
 		return nil, errors.Wrap(err, "preparing ethereum transaction")
 	}
 	return auth, nil
 }
 
-func Transfer(ctx context.Context, logger log.Logger, contract tellorCommon.Contract, account tellorCommon.Account, toAddress common.Address, amt *big.Int) error {
-	auth, err := prepareTransfer(ctx, contract.Getter, account, amt)
+func Transfer(ctx context.Context, logger log.Logger, client rpc.ETHClient, contract tellorCommon.Contract, account tellorCommon.Account, toAddress common.Address, amt *big.Int) error {
+	auth, err := prepareTransfer(ctx, client, contract.Getter, account, amt)
 	if err != nil {
 		return errors.Wrap(err, "preparing trasnfer")
 	}
@@ -55,8 +55,8 @@ func Transfer(ctx context.Context, logger log.Logger, contract tellorCommon.Cont
 	return nil
 }
 
-func Approve(ctx context.Context, logger log.Logger, contract tellorCommon.Contract, account tellorCommon.Account, _spender common.Address, amt *big.Int) error {
-	auth, err := prepareTransfer(ctx, contract.Getter, account, amt)
+func Approve(ctx context.Context, logger log.Logger, client rpc.ETHClient, contract tellorCommon.Contract, account tellorCommon.Account, _spender common.Address, amt *big.Int) error {
+	auth, err := prepareTransfer(ctx, client, contract.Getter, account, amt)
 	if err != nil {
 		return errors.Wrap(err, "preparing trasnfer")
 	}

--- a/pkg/ops/transferOps.go
+++ b/pkg/ops/transferOps.go
@@ -15,7 +15,6 @@ import (
 	"github.com/pkg/errors"
 	tellorCommon "github.com/tellor-io/TellorMiner/pkg/common"
 	"github.com/tellor-io/TellorMiner/pkg/contracts/getter"
-	"github.com/tellor-io/TellorMiner/pkg/contracts/tellor"
 	"github.com/tellor-io/TellorMiner/pkg/rpc"
 	"github.com/tellor-io/TellorMiner/pkg/util"
 )
@@ -24,13 +23,10 @@ import (
  * This is the operational transfer component. Its purpose is to transfer tellor tokens
  */
 
-func prepareTransfer(amt *big.Int, ctx context.Context) (*bind.TransactOpts, error) {
-	instance := ctx.Value(tellorCommon.ContractsGetterContextKey).(*getter.TellorGetters)
-	senderPubAddr := ctx.Value(tellorCommon.PublicAddress).(common.Address)
-
-	balance, err := instance.BalanceOf(nil, senderPubAddr)
+func prepareTransfer(ctx context.Context, instance *getter.TellorGetters, account tellorCommon.Account, amt *big.Int) (*bind.TransactOpts, error) {
+	balance, err := instance.BalanceOf(nil, account.Address)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get balance: %v", err)
+		return nil, errors.Wrap(err, "get balance")
 	}
 	fmt.Println("My balance", util.FormatERC20Balance(balance))
 	if balance.Cmp(amt) < 0 {
@@ -40,36 +36,34 @@ func prepareTransfer(amt *big.Int, ctx context.Context) (*bind.TransactOpts, err
 	}
 	auth, err := PrepareEthTransaction(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to prepare ethereum transaction: %s", err.Error())
+		return nil, errors.Wrap(err, "preparing ethereum transaction")
 	}
 	return auth, nil
 }
 
-func Transfer(ctx context.Context, logger log.Logger, toAddress common.Address, amt *big.Int) error {
-	auth, err := prepareTransfer(amt, ctx)
+func Transfer(ctx context.Context, logger log.Logger, contract tellorCommon.Contract, account tellorCommon.Account, toAddress common.Address, amt *big.Int) error {
+	auth, err := prepareTransfer(ctx, contract.Getter, account, amt)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "preparing trasnfer")
 	}
 
-	instance2 := ctx.Value(tellorCommon.ContractsTellorContextKey).(*tellor.Tellor)
-	tx, err := instance2.Transfer(auth, toAddress, amt)
+	tx, err := contract.Caller.Transfer(auth, toAddress, amt)
 	if err != nil {
-		return fmt.Errorf("contract failed: %s", err.Error())
+		return errors.Wrap(err, "calling transfer")
 	}
 	level.Info(logger).Log("msg", "transferred", "amount", util.FormatERC20Balance(amt), "to", toAddress.String()[:12], "tx Hash", tx.Hash().Hex())
 	return nil
 }
 
-func Approve(ctx context.Context, logger log.Logger, _spender common.Address, amt *big.Int) error {
-	auth, err := prepareTransfer(amt, ctx)
+func Approve(ctx context.Context, logger log.Logger, contract tellorCommon.Contract, account tellorCommon.Account, _spender common.Address, amt *big.Int) error {
+	auth, err := prepareTransfer(ctx, contract.Getter, account, amt)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "preparing trasnfer")
 	}
 
-	instance2 := ctx.Value(tellorCommon.ContractsTellorContextKey).(*tellor.Tellor)
-	tx, err := instance2.Approve(auth, _spender, amt)
+	tx, err := contract.Caller.Approve(auth, _spender, amt)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "calling approve")
 	}
 	level.Info(logger).Log("msg", "approved", "amount", util.FormatERC20Balance(amt), "spender", _spender.String()[:12], "tx Hash", tx.Hash().Hex())
 	return nil
@@ -78,11 +72,11 @@ func Approve(ctx context.Context, logger log.Logger, _spender common.Address, am
 func Balance(ctx context.Context, client rpc.ETHClient, getterInstance *getter.TellorGetters, addr common.Address) error {
 	ethBalance, err := client.BalanceAt(context.Background(), addr, nil)
 	if err != nil {
-		return fmt.Errorf("problem getting balance: %+v", err)
+		return errors.Wrap(err, "get eth balance")
 	}
 	trbBalance, err := getterInstance.BalanceOf(nil, addr)
 	if err != nil {
-		return errors.Wrapf(err, "getting balance")
+		return errors.Wrapf(err, "getting trb balance")
 	}
 	fmt.Printf("%s\n", addr.String())
 	fmt.Printf("%10s ETH\n", util.FormatERC20Balance(ethBalance))

--- a/pkg/ops/transferOps.go
+++ b/pkg/ops/transferOps.go
@@ -44,7 +44,7 @@ func prepareTransfer(ctx context.Context, client rpc.ETHClient, instance *getter
 func Transfer(ctx context.Context, logger log.Logger, client rpc.ETHClient, contract tellorCommon.Contract, account tellorCommon.Account, toAddress common.Address, amt *big.Int) error {
 	auth, err := prepareTransfer(ctx, client, contract.Getter, account, amt)
 	if err != nil {
-		return errors.Wrap(err, "preparing trasnfer")
+		return errors.Wrap(err, "preparing transfer")
 	}
 
 	tx, err := contract.Caller.Transfer(auth, toAddress, amt)
@@ -58,7 +58,7 @@ func Transfer(ctx context.Context, logger log.Logger, client rpc.ETHClient, cont
 func Approve(ctx context.Context, logger log.Logger, client rpc.ETHClient, contract tellorCommon.Contract, account tellorCommon.Account, _spender common.Address, amt *big.Int) error {
 	auth, err := prepareTransfer(ctx, client, contract.Getter, account, amt)
 	if err != nil {
-		return errors.Wrap(err, "preparing trasnfer")
+		return errors.Wrap(err, "preparing transfer")
 	}
 
 	tx, err := contract.Caller.Approve(auth, _spender, amt)

--- a/pkg/ops/util.go
+++ b/pkg/ops/util.go
@@ -5,23 +5,17 @@ package ops
 
 import (
 	"context"
-	"crypto/ecdsa"
 	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/common"
 	tellorCommon "github.com/tellor-io/TellorMiner/pkg/common"
 	"github.com/tellor-io/TellorMiner/pkg/rpc"
 )
 
-func PrepareEthTransaction(ctx context.Context) (*bind.TransactOpts, error) {
+func PrepareEthTransaction(ctx context.Context, client rpc.ETHClient, account tellorCommon.Account) (*bind.TransactOpts, error) {
 
-	client := ctx.Value(tellorCommon.ClientContextKey).(rpc.ETHClient)
-
-	publicAddress := ctx.Value(tellorCommon.PublicAddress).(common.Address)
-
-	nonce, err := client.PendingNonceAt(ctx, publicAddress)
+	nonce, err := client.PendingNonceAt(ctx, account.Address)
 	if err != nil {
 		return nil, fmt.Errorf("problem getting pending nonce: %+v", err)
 	}
@@ -31,7 +25,7 @@ func PrepareEthTransaction(ctx context.Context) (*bind.TransactOpts, error) {
 		return nil, fmt.Errorf("problem getting gas price: %+v", err)
 	}
 
-	ethBalance, err := client.BalanceAt(ctx, publicAddress, nil)
+	ethBalance, err := client.BalanceAt(ctx, account.Address, nil)
 	if err != nil {
 		return nil, fmt.Errorf("problem getting balance: %+v", err)
 	}
@@ -42,8 +36,7 @@ func PrepareEthTransaction(ctx context.Context) (*bind.TransactOpts, error) {
 		return nil, fmt.Errorf("insufficient ethereum to send a transaction: %v < %v", ethBalance, cost)
 	}
 
-	privateKey := ctx.Value(tellorCommon.PrivateKey).(*ecdsa.PrivateKey)
-	auth := bind.NewKeyedTransactor(privateKey)
+	auth := bind.NewKeyedTransactor(account.PrivateKey)
 	auth.Nonce = big.NewInt(int64(nonce))
 	auth.Value = big.NewInt(0)      // in wei
 	auth.GasLimit = uint64(3000000) // in units

--- a/pkg/ops/util.go
+++ b/pkg/ops/util.go
@@ -5,17 +5,9 @@ package ops
 
 import (
 	"context"
-
-	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-
-	"crypto/ecdsa"
-	"math/big"
-
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 
 	tellorCommon "github.com/tellor-io/TellorMiner/pkg/common"


### PR DESCRIPTION
To avoid functions with 7+ parameters, I created structs for the main pieces previously used in the contex.

Otherwise, the last big piece that we still rely on the ctx is the DB, which I'll tackle next.