### PR TITLE
merge docs from TellorDocs

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,8 @@
+* [Become a Miner](miner.md)
+* [The Guide](the-guide.md)
+* [Configuation](configuation.md)
+* [Contributing](contributing.md)
+* [Coding style guide](coding-style-guide.md)
+* [Release process](release-process.md)
+* [Reference](miner-reference.md)
+* [Disclaimer](disclaimer.md)

--- a/docs/coding-style-guide.md
+++ b/docs/coding-style-guide.md
@@ -1,3 +1,7 @@
+---
+description: Coding style guide for contributors.
+---
+
 # Coding Style Guide
 
 This document details the official style guides for the various languages we use in the project.

--- a/docs/configuation.md
+++ b/docs/configuation.md
@@ -34,7 +34,7 @@ If you have multiple GPUs connected, you can specify different config settings f
             "groupSize":256,
             "groups":4096,
             "count":16
-        }, 
+        },
         "<GPUName3>":{
             "disabled":true
         },

--- a/docs/configuation.md
+++ b/docs/configuation.md
@@ -1,0 +1,116 @@
+---
+description: Tweaks and settings to keep your rig running smoothly.
+---
+
+# Configuation
+
+## useGPU
+
+If you have one or more GPUs, they will be used for mining by default. Currently only Nvidia cards are supported, and the default behavior will work well for miners.
+
+You can configure your GPUs as you wish by adding / editing the following lines in your config.json file:
+
+```text
+"useGPU":true,
+        "gpuConfig":{
+        "default":{
+            "groupSize":256,
+            "groups":4096,
+            "count":16
+        }
+    },
+```
+
+If you have multiple GPUs connected, you can specify different config settings for each card in the following format:
+
+```text
+"gpuConfig":{
+        "<GPUName1>":{
+            "groupSize":256,
+            "groups":4096,
+            "count":16
+        },
+        "<GPUName2>":{
+            "groupSize":256,
+            "groups":4096,
+            "count":16
+        }, 
+        "<GPUName3>":{
+            "disabled":true
+        },
+
+    }
+```
+
+Replace "GPUName1" with system name for each card. On most systems you can get a list of GPUs with `nvidia-smi -l`
+
+You may edit the variables to try to improve hashrate for your GPU model:
+
+* disabled: boolean on whether or not to disable a specific GPU
+* groupSize - number of groups to split work into
+* groups - number of groups of work submitted to the gpu at once
+* count: number of hashes each thread executes in one pass
+
+{% hint style="info" %}
+Edit these variables at your own risk! Reach out to the community if you're unsure.
+{% endhint %}
+
+## Connecting to a Pool
+
+There are mining pools available for mining TRB without staking 500 tokens. The pool server operator stakes 500 tokens for you, and you receive rewards roughly proportional to your hashrate as a fraction of the pool's hashrate.
+
+{% hint style="info" %}
+Each pool as different fees and instructions for hooking up. Be sure to read your pools documentation. Feel free to reach out to the community if you need help with mining pools.
+{% endhint %}
+
+Add the following lines to your config file:
+
+```text
+"enablePoolWorker": true,
+"poolURL": "<poolURL>",
+```
+
+Where the poolURL is the link to your pool. \(e.g. [http://tellorpool.org](http://tellorpool.org) \)
+
+You can change the job duration if needed. This is the time in seconds to grab information from the pool. The default time is 15 seconds.
+
+```text
+"poolJobDuration":10
+```
+
+## Running a Remote Data Server for Multiple Miners
+
+{% hint style="info" %}
+If you are setting up a Tellor miner for the first time, it might be a good idea to skip this section and come back after you're up and running with one miner.
+{% endhint %}
+
+If you are running multiple miners, there is no reason to run multiple databases \(the values you will submit should be identical\). In addition, querying the same API from multiple processes can lead to rate limits on the public API's. To get around this, you can utilize a system where you run one.
+
+`tellor dataServer`
+
+You can then start multiple miners that all read off the one database.
+
+`tellor mine -r`
+
+Create a config file for the dataServer and add the public addresses of all remote miners that want to read the database: \(0x prefix is retained here\)
+
+```text
+    “serverWhitelist”: [
+        "0xyour-miner-address1",
+        "0xyour-miner-address2"
+    ]
+```
+
+Create a separate copy of config.json for each miner and edit these to match your miner's characteristics.
+
+In both your miner and dataServer config files, you must change the IP addresses to match the server and port you are hosting/reading from.
+
+```text
+   "serverHost": "1.2.3.4",
+   "serverPort": 5000,
+```
+
+Note that your dataServer and miners must be started with separate commands.
+
+For more detailed instructions:[ https://docs.google.com/document/d/1k8ELb1cXkEpztHkHUt8QTL4JCcnHw5\_yQjTKIHCaSCE](https://docs.google.com/document/d/1k8ELb1cXkEpztHkHUt8QTL4JCcnHw5_yQjTKIHCaSCE)
+

--- a/docs/configuation.md
+++ b/docs/configuation.md
@@ -34,7 +34,7 @@ If you have multiple GPUs connected, you can specify different config settings f
             "groupSize":256,
             "groups":4096,
             "count":16
-        },
+        }, 
         "<GPUName3>":{
             "disabled":true
         },

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,8 @@
-# Contributing
-This document explain the process of contributing to the project.
+---
+description: Process of contributing to the project.
+---
 
+# Contributing
 
 ## Philosophy
 - The philosophy is borrowing much from UNIX philosophy and the golang programming language.Each sub command should do one thing and do it well

--- a/docs/disclaimer.md
+++ b/docs/disclaimer.md
@@ -1,0 +1,10 @@
+---
+description: Mine at your own risk.
+---
+
+# Disclaimer
+
+If you are building a competing client, please contact us.  A lot of the miner specifications are off-chain and a significant portion of the mining process hinges on the consensus of the Tellor community to determine what proper values are.  Competing clients that change different pieces run the risk of being disputed by the community.
+
+As an example, request ID 4 is BTC/USD. If the api's all go down, it is the responsibility of the miner to still submit a valid BTC/USD price. If they do not, they risk being disputed and slashed. For these reasons, please contribute openly to the official Tellor miner \(or an open source variant\), as consensus here is key. If your miner gets a different value than the majority of the other miners, you risk being punished!
+

--- a/docs/miner-reference.md
+++ b/docs/miner-reference.md
@@ -1,0 +1,66 @@
+---
+description: TellorMiner commands and config file options are found here.
+---
+
+# Reference
+
+#### Required Flags <a id="docs-internal-guid-d1a57725-7fff-a753-9236-759dd3f42eed"></a>
+
+* `--config` \(path to your config file.\)
+
+#### TellorMiner Commands
+
+* `--logConfig` \(location of logging config file; default path is current directory\)
+* `mine` \(indicates to run the miner\)
+* `mine -r` \(indicates to mine utilizing a remote server\)
+* `dataserver` \(indicates to run the dataServer \(no mining\)\)
+* `transfer` \(AMOUNT\) \(TOADDRESS\) \(indicates transfer, toAddress is Ethereum address and amount is number of Tributes \(eg. transfer 10 0xea... \(this transfers 10 tokens\)\)\)
+* `approve` \(AMOUNT\) \(TOADDRESS\) \(ammount to approve the toaddress to send this amount of tokens
+* `stake deposit` \(indicates to deposit 1000 tokens in the contract\)
+* `stake request` \(indicates you wish to withdraw your stake\)
+* `stake withdraw` \(withdraws your stake, run 1 week after request\)
+* `stake status` \(shows your staking balance\)
+* `balance` \(shows your balance\)
+
+#### Config file options:
+
+* `contractAddress` \(required\) - address of TellorContract
+* `nodeURL` \(required\) - node URL \(e.g https://mainnet.infura.io/bbbb or https://localhost:8545 if own node\)
+* `privateKey` \(required\) - privateKey for your address
+* `databaseURL` \(required\) - where you are reading from for the server database \(if hosted\)
+* `publicAddress` \(required\) - public address for your miner \(note, no 0x\)
+* `ethClientTimeout` \(required\) - timeout for making requests from your node
+* `trackerCycle` \(required\) - how often your database updates \(in seconds\)
+* `trackers` \(required\) - which pieces of the database you update
+* `dbFile` \(required\) - where you want to store your local database \(if self-hosting\)
+* `serverHost` \(required\) - location to host server
+* `serverWhitelist` \(required\) - whitelists which publicAddress can access the data server
+* `fetchTimeout` - timeout for requesting data from an API
+* `requestData` - sets wether your miner request data if challenge is 0.  If yes, then you will addTip\(\) to this number.  Enter a uint number representing request id to be requested \(e.g. 2\)
+* `requestDataInterval` - min frequency at which to request data at \(in seconds, default 30\)
+* `gasMultiplier` - Multiplies the submitted gasPrice \(e.g. 2 will double gas costs\)
+* `gasMax` - a max for the gas price in gwei \(note: this max comes BEFORE the gas multiplier.  So a max gas cost of 10 gwei, can have gas prices up to 20 if gasMultiplier is 2\)
+* `heartbeat` - an integer that controls how frequently the miner process should report the hashrate \(larger is less frequent, try 1000000 to start\)
+* `numProcessors` - an integer number of CPU cores/threads to use for mining. \(cpu mining is disabled if there is a suitable GPU is found
+* `disputeTimeDelta` - how far back to store values for min/max range - default 5 \(in minutes\)
+* `disputeThreshold` - percentage of acceptable range outside min/max for dispute checking - default 
+* `psrFolder` - folder location holding your psr.json file, default working directory 
+
+#### LogConfig file options:
+
+The logging.config file consists of two fields: \* component \* level
+
+The component is the package.component combination.
+
+E.G. the Runner component in the tracker package would be: tracker.Runner
+
+To turn on logging, add the component and the according level. Note the default level is "INFO", so to turn down the number of logs, enter "WARN" or "ERROR"
+
+DEBUG - logs everything in INFO and additional developer logs
+
+INFO - logs most information about the mining operation
+
+WARN - logs all warnings and errors
+
+ERROR - logs only serious errors
+

--- a/docs/miner-reference.md
+++ b/docs/miner-reference.md
@@ -43,8 +43,8 @@ description: TellorMiner commands and config file options are found here.
 * `heartbeat` - an integer that controls how frequently the miner process should report the hashrate \(larger is less frequent, try 1000000 to start\)
 * `numProcessors` - an integer number of CPU cores/threads to use for mining. \(cpu mining is disabled if there is a suitable GPU is found
 * `disputeTimeDelta` - how far back to store values for min/max range - default 5 \(in minutes\)
-* `disputeThreshold` - percentage of acceptable range outside min/max for dispute checking - default
-* `psrFolder` - folder location holding your psr.json file, default working directory
+* `disputeThreshold` - percentage of acceptable range outside min/max for dispute checking - default 
+* `psrFolder` - folder location holding your psr.json file, default working directory 
 
 #### LogConfig file options:
 

--- a/docs/miner-reference.md
+++ b/docs/miner-reference.md
@@ -43,8 +43,8 @@ description: TellorMiner commands and config file options are found here.
 * `heartbeat` - an integer that controls how frequently the miner process should report the hashrate \(larger is less frequent, try 1000000 to start\)
 * `numProcessors` - an integer number of CPU cores/threads to use for mining. \(cpu mining is disabled if there is a suitable GPU is found
 * `disputeTimeDelta` - how far back to store values for min/max range - default 5 \(in minutes\)
-* `disputeThreshold` - percentage of acceptable range outside min/max for dispute checking - default 
-* `psrFolder` - folder location holding your psr.json file, default working directory 
+* `disputeThreshold` - percentage of acceptable range outside min/max for dispute checking - default
+* `psrFolder` - folder location holding your psr.json file, default working directory
 
 #### LogConfig file options:
 

--- a/docs/miner.md
+++ b/docs/miner.md
@@ -1,0 +1,21 @@
+---
+description: >-
+  Use your compute power to help secure Tellor's decentralized data feeds.
+  Receive rewards in TRB.
+---
+
+# Become a Miner
+
+For over a decade now, the Bitcoin network has shown how proof-of-work can incentivize individuals and companies to compete for the honor of finding block rewards and achieving consensus. This phenomenon is global, and anonymous. The network is democratized and decentralized, because the creators have no direct control over who is providing computing power on their network. 
+
+Tellor takes this concept and applies it directly to the delivery of oracle data. Anyone who is able may start up TellorMiner and begin competing for blocks. There is no whitelisting. Miners compete very much the same way that Bitcoin miners do, but with a twist. _Tellor Miners must also run a database from which to pull values to submit to the Tellor oracle._ When a "block" is found, the winners submit their data. 
+
+Mining is one of the most exciting ways to help Tellor grow and become a leader in the DeFi / Oracle space. Here are a few things to consider before jumping in:
+
+As of now, mining requires you deposit 500 Tellor Tributes. These are a security deposit. If you are a malicious actor \(aka submit a bad value\), the community can vote to slash your 500 tokens.
+
+* Mining requires access to an Ethereum node. If you don’t have your own node, you can use an Infura API endpoint.
+* Miners must hold a balance of ETH to cover gas fees, which can be significant. Please reach out to the community to find the best tips for keeping gas costs under control.
+
+The guide that follows assumes that you have access to a suitable machine running linux to use for mining. For information about what constitutes a "suitable machine", we recommend reaching out to the community. 
+

--- a/docs/miner.md
+++ b/docs/miner.md
@@ -6,9 +6,9 @@ description: >-
 
 # Become a Miner
 
-For over a decade now, the Bitcoin network has shown how proof-of-work can incentivize individuals and companies to compete for the honor of finding block rewards and achieving consensus. This phenomenon is global, and anonymous. The network is democratized and decentralized, because the creators have no direct control over who is providing computing power on their network.
+For over a decade now, the Bitcoin network has shown how proof-of-work can incentivize individuals and companies to compete for the honor of finding block rewards and achieving consensus. This phenomenon is global, and anonymous. The network is democratized and decentralized, because the creators have no direct control over who is providing computing power on their network. 
 
-Tellor takes this concept and applies it directly to the delivery of oracle data. Anyone who is able may start up TellorMiner and begin competing for blocks. There is no whitelisting. Miners compete very much the same way that Bitcoin miners do, but with a twist. _Tellor Miners must also run a database from which to pull values to submit to the Tellor oracle._ When a "block" is found, the winners submit their data.
+Tellor takes this concept and applies it directly to the delivery of oracle data. Anyone who is able may start up TellorMiner and begin competing for blocks. There is no whitelisting. Miners compete very much the same way that Bitcoin miners do, but with a twist. _Tellor Miners must also run a database from which to pull values to submit to the Tellor oracle._ When a "block" is found, the winners submit their data. 
 
 Mining is one of the most exciting ways to help Tellor grow and become a leader in the DeFi / Oracle space. Here are a few things to consider before jumping in:
 
@@ -17,5 +17,5 @@ As of now, mining requires you deposit 500 Tellor Tributes. These are a security
 * Mining requires access to an Ethereum node. If you don’t have your own node, you can use an Infura API endpoint.
 * Miners must hold a balance of ETH to cover gas fees, which can be significant. Please reach out to the community to find the best tips for keeping gas costs under control.
 
-The guide that follows assumes that you have access to a suitable machine running linux to use for mining. For information about what constitutes a "suitable machine", we recommend reaching out to the community.
+The guide that follows assumes that you have access to a suitable machine running linux to use for mining. For information about what constitutes a "suitable machine", we recommend reaching out to the community. 
 

--- a/docs/miner.md
+++ b/docs/miner.md
@@ -6,9 +6,9 @@ description: >-
 
 # Become a Miner
 
-For over a decade now, the Bitcoin network has shown how proof-of-work can incentivize individuals and companies to compete for the honor of finding block rewards and achieving consensus. This phenomenon is global, and anonymous. The network is democratized and decentralized, because the creators have no direct control over who is providing computing power on their network. 
+For over a decade now, the Bitcoin network has shown how proof-of-work can incentivize individuals and companies to compete for the honor of finding block rewards and achieving consensus. This phenomenon is global, and anonymous. The network is democratized and decentralized, because the creators have no direct control over who is providing computing power on their network.
 
-Tellor takes this concept and applies it directly to the delivery of oracle data. Anyone who is able may start up TellorMiner and begin competing for blocks. There is no whitelisting. Miners compete very much the same way that Bitcoin miners do, but with a twist. _Tellor Miners must also run a database from which to pull values to submit to the Tellor oracle._ When a "block" is found, the winners submit their data. 
+Tellor takes this concept and applies it directly to the delivery of oracle data. Anyone who is able may start up TellorMiner and begin competing for blocks. There is no whitelisting. Miners compete very much the same way that Bitcoin miners do, but with a twist. _Tellor Miners must also run a database from which to pull values to submit to the Tellor oracle._ When a "block" is found, the winners submit their data.
 
 Mining is one of the most exciting ways to help Tellor grow and become a leader in the DeFi / Oracle space. Here are a few things to consider before jumping in:
 
@@ -17,5 +17,5 @@ As of now, mining requires you deposit 500 Tellor Tributes. These are a security
 * Mining requires access to an Ethereum node. If you don’t have your own node, you can use an Infura API endpoint.
 * Miners must hold a balance of ETH to cover gas fees, which can be significant. Please reach out to the community to find the best tips for keeping gas costs under control.
 
-The guide that follows assumes that you have access to a suitable machine running linux to use for mining. For information about what constitutes a "suitable machine", we recommend reaching out to the community. 
+The guide that follows assumes that you have access to a suitable machine running linux to use for mining. For information about what constitutes a "suitable machine", we recommend reaching out to the community.
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,6 +1,8 @@
-# Release Process
+---
+description: Release cadence and process for the project.
+---
 
-This page describes the release cadence and process for the project.
+# Release Process
 
 We use [Semantic Versioning](http://semver.org/).
 

--- a/docs/the-guide.md
+++ b/docs/the-guide.md
@@ -1,0 +1,145 @@
+---
+description: Here are the nuts and bolts for mining TRB.
+---
+
+# The Guide
+
+## Download the Latest TellorMiner
+
+This is the workhorse of the Miner system.
+
+[https://github.com/tellor-io/TellorMiner/releases](https://github.com/tellor-io/TellorMiner/releases)
+
+```text
+wget https://github.com/tellor-io/TellorMiner/releases/[release-num]/download/tellor
+```
+
+Depending on your miner setup you may need to give TellorMiner permission to run. If so, this will need to be done after updates as well.
+
+```text
+chmod +x tellor
+```
+
+## Download and Edit config.json
+
+config.json is where you will enter your wallet address and configure TellorMiner for your machine.
+
+```text
+wget https://raw.githubusercontent.com/tellor-io/TellorMiner/master/configs/config.json
+```
+
+Open config.json and update the following values:
+
+* Set `"nodeURL"` to an Ethereum node endpoint. \(e.g. Infura API endpoint\)
+* Set `"publicAddress"` to the public key for the Ethereum wallet you plan to use for mining. Remove the 0x prefix at the beginning of the address.
+
+## Create .env file
+
+Create a file named `configs/.env` \(Note: This step can be skipped in you plan to mine on a pool.\)
+
+Copy and paste the following into your `.env` file, and edit this to match your mining address private key.
+
+```text
+ETH_PRIVATE_KEY="3a10b4bc1258e8bfefb95b498fb8c0f0cd6964a811eabca87df56xxxxxxxxxxxx"
+```
+
+## Download the API Index and Logging Config Files
+
+Run the following commands:
+
+```text
+wget https://raw.githubusercontent.com/tellor-io/TellorMiner/master/configs/indexes.json
+
+wget https://raw.githubusercontent.com/tellor-io/TellorMiner/master/configs/loggingConfig.json
+```
+
+## Download and Edit the Manual Data Entry File
+
+Tellor currently has one data point which must be manually created. The rolling 3 month average of the US PCE . It is updated monthly. _Make sure to keep this file up to date._
+
+Run the following command:
+
+```text
+wget https://raw.githubusercontent.com/tellor-io/TellorMiner/master/configs/manualData.json
+```
+
+For testing purposes, or if you want to hardcode in a specific value to enter, you can use the manualdata.json file to add manual data for a given requestID. Similar to the manual data structure, you add the request ID, a given value \(with granularity\), and a date which the manual data is valid until.
+
+The following example shows request ID 4, inputting a value of 9000 with a 1,000,000 granularity. Note the date is a unix timestamp.
+
+```text
+"4":{
+    "VALUE":9000000000,
+    "DATE":1596153600
+}
+```
+
+## Deposit your Initial Stake
+
+You will need 500 TRB to run your own server for mining. Your stake is locked for a minimum of 7 days after you run the command to request withdrawal.
+
+{% hint style="info" %}
+You do not need to stake 500 TRB if you plan to mine on a pool.
+{% endhint %}
+
+Run the following command to deposit your stake:
+
+```text
+tellor --config=./configs/config.json stake deposit
+```
+
+If needed, change the name of config.json to match the name of your config file.
+
+## Run the miner
+
+Start the dataServer:
+
+```text
+tellor --config=./configs/config.json dataServer
+```
+
+Start the miner by running this command in another terminal or process:
+
+```text
+tellor --config=./configs/config.json mine
+```
+
+After starting the miner, observe the logs it outputs to confirm it's working correctly. In the next section we will look at some configuration options that can help improve performance.
+
+## Unstaking / Ending Mining Operations
+
+To unstake your tokens, you need to request a withdraw:
+
+```text
+tellor --config=./configs/config.json stake request
+```
+
+One week after the request, the tokens are free to move at your discretion after running the command:
+
+```text
+tellor --config=./configs/config.json stake withdraw
+```
+
+## Running the Disputer
+
+Tellor as a system only functions properly if parties actively monitor the tellor network and dispute bad values. Expecting parties to manually look at every value submitted is obviously burdensome. The Tellor disputer automates this fact checking of values.
+
+The way that it work is that your dataServer will store historical values \(e.g. the last 10 minutes\) and then compare any submitted values to the min/max of the historical values. If the value submitted is outside a certain threshold \(e.g. 10% of the min/max\), then the party will be notified and they can choose if they wish to dispute the bad value.
+
+To start the disputer, add the following line to your config file IN THE TRACKERS ARRAY:
+
+```text
+"disputeChecker"
+```
+
+Now when running the dataServer, you will store historical values and check for whether the submitted values were within min/max of the range of historical values given a threshold \(e.g. 1% outside\). The variables for configuring the time range of the historical values and the threshold are as follows:
+
+```text
+  disputeTimeDelta: 5,
+  disputeThreshold: 0.01,
+```
+
+Where 5 and .01 are the defaults, the variables are the amount of time in minutes to store historical values for comparison and the the threshold outside the min/max of the values \(e.g. 0.01 = 1%\);
+
+If the disputer is successful and finds a submitted outside of your acceptable range, a text file containing pertinent information will be created in your working directory \(the one you're running the miner out of\) in the format: `"possible-dispute-(blocktime).txt"`
+


### PR DESCRIPTION
### Description
This PR moves all docs from `https://github.com/tellor-io/TellorDocs/tree/master/miner-documentation` to this repo in the `/docs` folder and convert them to the Gitbook format.
Also, I must note INDEX.md file. We'll use INDEX.md for the repo sync process in another PR.
### Refs 
#268 