### PR TITLE
Better handling the env vars when the env file is missing.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -160,7 +160,8 @@ func ParseConfigBytes(data []byte) error {
 		return errors.Wrap(err, "parse config json")
 	}
 	err = godotenv.Load(defaultConfig.EnvFile)
-	if err != nil {
+	// Ignore file doesn't exist errors.
+	if err != nil && !os.IsNotExist(err) {
 		return errors.Wrap(err, "loading .env file")
 	}
 

--- a/pkg/tracker/index.go
+++ b/pkg/tracker/index.go
@@ -61,15 +61,14 @@ func parseIndexFile() (trackersPerURL map[string]*IndexTracker, symbolsForAPI ma
 			// Tracker for this API already added?
 			_, ok := trackersPerURL[api.URL]
 			if !ok {
-
 				// Expand any env variables with their values from the .env file.
-				vars, err := godotenv.Read(cfg.EnvFile)
+				_, err := godotenv.Read(cfg.EnvFile)
 				// Ignore file doesn't exist errors.
-				if _, ok := err.(*os.PathError); err != nil && !ok {
+				if err != nil && !os.IsNotExist(err) {
 					return nil, nil, errors.Wrap(err, "reading .env file")
 				}
 				api.URL = os.Expand(api.URL, func(key string) string {
-					return vars[key]
+					return os.Getenv(key)
 				})
 
 				var name string


### PR DESCRIPTION
This also allow to run telliot without an  env variables and use existing exported env vars.
This also simplifies running it as a container in k8s


Signed-off-by: Krasi Georgiev <8903888+krasi-georgiev@users.noreply.github.com>