### PR TITLE
Make the minimum submit configurable

### DIFF
--- a/configs/config.json
+++ b/configs/config.json
@@ -6,6 +6,20 @@
     "gasMax": 10,
     "dbFile": "/tellorDB",
     "configFolder": "/configs",
+    "envFile": "configs/.env.example",
     "logLevel": "info",
-    "envFile": "configs/.env.example"
+    "Logger": {
+        "config.Config": "INFO",
+        "db.DB": "INFO",
+        "rpc.client": "INFO",
+        "rpc.ABICodec": "INFO",
+        "rpc.mockClient": "INFO",
+        "tracker.Top50Tracker": "INFO",
+        "tracker.FetchDataTracker": "INFO",
+        "pow.MiningWorker-0:": "INFO",
+        "pow.MiningWorker-1:": "INFO",
+        "pow.MiningTasker-0:": "INFO",
+        "pow.MiningTasker-1:": "INFO",
+        "tracker.PSRTracker": "INFO"
+    }
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -60,6 +60,7 @@ type Config struct {
 	ContractAddress              string                `json:"contractAddress"`
 	PublicAddress                string                `json:"publicAddress"`
 	EthClientTimeout             uint                  `json:"ethClientTimeout"`
+	MinSubmitPeriod              time.Duration         `json:"minSubmitPeriod"`
 	TrackerSleepCycle            Duration              `json:"trackerCycle"`
 	Trackers                     map[string]bool       `json:"trackers"`
 	DBFile                       string                `json:"dbFile"`
@@ -100,6 +101,7 @@ var defaultConfig = Config{
 	GasMax:                       10,
 	GasMultiplier:                1,
 	MinConfidence:                0.2,
+	MinSubmitPeriod:              15 * time.Minute,
 	DisputeThreshold:             0.01,
 	ServerHost:                   "localhost",
 	ServerPort:                   8080,

--- a/pkg/ops/miningManager.go
+++ b/pkg/ops/miningManager.go
@@ -28,8 +28,6 @@ import (
 	"github.com/tellor-io/telliot/pkg/tracker"
 )
 
-var minSubmitPeriod = 15 * time.Minute
-
 type WorkSource interface {
 	GetWork(toMine chan *pow.Work) (*pow.Work, bool)
 }
@@ -159,8 +157,8 @@ func (mgr *MiningMgr) Start(ctx context.Context) {
 			lastSubmit, err := mgr.lastSubmit()
 			if err != nil {
 				level.Error(mgr.logger).Log("msg", "checking last submit time", "err", err)
-			} else if lastSubmit < minSubmitPeriod {
-				level.Debug(mgr.logger).Log("msg", "min transaction submit threshold hasn't passed", "minSubmitPeriod", minSubmitPeriod, "lastSubmit", lastSubmit)
+			} else if lastSubmit < mgr.cfg.MinSubmitPeriod {
+				level.Debug(mgr.logger).Log("msg", "min transaction submit threshold hasn't passed", "minSubmitPeriod", mgr.cfg.MinSubmitPeriod, "lastSubmit", lastSubmit)
 				continue
 			}
 			tx, err := mgr.solHandler.Submit(ctx, solution)


### PR DESCRIPTION
This is so that in development can use TellorPlayground to submit
transactions faster which will speed up the debugging during
development. At the moment it doesn't work because of the contract
binding, but at some point will see how we can fix this.

Signed-off-by: Krasi Georgiev <8903888+krasi-georgiev@users.noreply.github.com>