### PR TITLE
Split the k8s manifests to persist the disks

### DIFF
--- a/configs/manifests/monitoring-persist.yml
+++ b/configs/manifests/monitoring-persist.yml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometheus
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi  # If you change this make sure to update the prometheus meta disk retention settings.
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+spec:
+  type: LoadBalancer
+  selector:
+    app: grafana
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: grafana

--- a/configs/manifests/monitoring.yml
+++ b/configs/manifests/monitoring.yml
@@ -1,28 +1,4 @@
 apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: prometheus
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 50Gi  # If you change this make sure to update the prometheus meta disk retention settings.
----
-
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: grafana
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 5Gi
-
----
-apiVersion: v1
 kind: ConfigMap
 metadata:
   name: prometheus
@@ -47,7 +23,7 @@ data:
       relabel_configs:
       - action: keep
         source_labels: [__meta_kubernetes_service_label_app]
-        regex: telliot|prometheus
+        regex: telliot|prometheus|geth-exporter
       - action: replace
         source_labels: [__meta_kubernetes_service_label_app]
         target_label: job
@@ -66,12 +42,10 @@ spec:
   selector:
     matchLabels:
       app: prometheus
-      prometheus: main
   template:
     metadata:
       labels:
         app: prometheus
-        prometheus: main
     spec:
       serviceAccountName: prometheus
       securityContext:
@@ -83,8 +57,7 @@ spec:
         - "--storage.tsdb.path=/data"
         - "--storage.tsdb.no-lockfile"
         - "--storage.tsdb.retention.size=40GB" 
-        - "--web.enable-lifecycle"
-        
+        - "--web.enable-lifecycle" 
         name: prometheus
         volumeMounts:
         - name: config-volume
@@ -109,7 +82,6 @@ kind: Service
 metadata:
   name: prometheus
   labels:
-    prometheus: main
     app: prometheus
 spec:
   ports:
@@ -118,7 +90,6 @@ spec:
     targetPort: prometheus
   selector:
     app: prometheus
-    prometheus: main
 
 ---
 apiVersion: v1
@@ -155,18 +126,15 @@ metadata:
   name: grafana
   labels:
     app: grafana
-    component: core
 spec:
   replicas: 1
   selector:
     matchLabels:
         app: grafana
-        component: core
   template:
     metadata:
       labels:
         app: grafana
-        component: core
     spec:
       securityContext:
         runAsUser: 472
@@ -183,7 +151,7 @@ spec:
           - name: GF_AUTH_ANONYMOUS_ENABLED
             value: "true"
           - name: GF_AUTH_ANONYMOUS_ORG_NAME
-            value: "Tellior.io"
+            value: "Main Org." # Don't change or it will disable anonymous access.
           - name: GF_USERS_VIEWERS_CAN_EDIT
             value: "false"
         volumeMounts:
@@ -201,16 +169,3 @@ spec:
       - name: grafana-datasource-provision
         configMap:
           name: grafana-datasource-provision
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: grafana
-spec:
-  type: LoadBalancer
-  selector:
-    app: grafana
-  ports:
-  - protocol: TCP
-    port: 80
-    targetPort: grafana

--- a/docs/setup-and-usage.md
+++ b/docs/setup-and-usage.md
@@ -39,6 +39,7 @@ kubectl apply -f https://raw.githubusercontent.com/tellor-io/telliot/master/conf
 ```
  - Optionally deploy the monitoring stack with Prometheus and Grafana.
 ```bash
+kubectl apply -f https://raw.githubusercontent.com/tellor-io/telliot/master/configs/manifests/monitoring-persist.yml
 kubectl apply -f https://raw.githubusercontent.com/tellor-io/telliot/master/configs/manifests/monitoring.yml
 ```
 


### PR DESCRIPTION
When deleting the containers we want to persist the disks so that is why
these are no in a separate file.

Signed-off-by: Krasi Georgiev <8903888+krasi-georgiev@users.noreply.github.com>