### PR TITLE
Remove the timezone in log format as the default is always UTC

### DIFF
--- a/pkg/util/logger.go
+++ b/pkg/util/logger.go
@@ -170,6 +170,6 @@ func SetupLogger() func(string) log.Logger {
 
 		logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
 		logger = level.NewFilter(logger, lvl)
-		return log.With(logger, "ts", log.TimestampFormat(func() time.Time { return time.Now().UTC() }, "Jan 02 15:04:05.99 -0700"), "caller", log.DefaultCaller)
+		return log.With(logger, "ts", log.TimestampFormat(func() time.Time { return time.Now().UTC() }, "Jan 02 15:04:05.99"), "caller", log.DefaultCaller)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Krasi Georgiev <8903888+krasi-georgiev@users.noreply.github.com>