### PR TITLE
Fixing null pointer exception

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -120,7 +120,7 @@ var defaultConfig = Config{
 	Mine: Mine{
 		ListenHost:   "localhost",
 		ListenPort:   9090,
-		RemoteDBHost: "localhost",
+		RemoteDBHost: "",
 		RemoteDBPort: 5000,
 	},
 	DataServer: DataServer{


### PR DESCRIPTION
The default string for remoteDB host was making the checks to identify weather we're in remote mining mode fail. 