### PR TITLE
Calculating time vars per request for anyblock, and cryptocompare

### DIFF
--- a/configs/index.json
+++ b/configs/index.json
@@ -104,11 +104,11 @@
                 "param": "$.content[0][vwap]"
             },
             {
-                "URL": "https://api.anyblock.tools/market/AMPL_USD_via_ALL/daily-volume?roundDay=false&debug=false&access_token=$ANYBLOCK_KEY&start=$BOD_MILLISECONDS&end=$EOD_MILLISECONDS",
+                "URL": "https://api.anyblock.tools/market/AMPL_USD_via_ALL/daily-volume?roundDay=false&debug=false&access_token=$ANYBLOCK_KEY",
                 "param": "$.overallVWAP"
             },
             {
-                "URL": "https://min-api.cryptocompare.com/data/dayAvg?fsym=AMPL&tsym=USD&toTs=$EOD_SECONDS&api_key=$CC_KEY",
+                "URL": "https://min-api.cryptocompare.com/data/dayAvg?fsym=AMPL&tsym=USD&api_key=$CC_KEY",
                 "param": "$.USD"
             }
         ]

--- a/pkg/tracker/index/index.go
+++ b/pkg/tracker/index/index.go
@@ -122,8 +122,7 @@ func createDataSources(ctx context.Context, cfg Config, client *ethclient.Client
 			var err error
 
 			// Fail early when api url is missing env var.
-			url := web.ExpandTimeVars(endpoint.URL)
-			endpoint.URL = os.Expand(url, func(key string) string {
+			endpoint.URL = os.Expand(endpoint.URL, func(key string) string {
 				if os.Getenv(key) == "" {
 					err = errors.Errorf("missing required env variable in index url:%v", key)
 				}
@@ -385,7 +384,6 @@ func NewJSONapiVolume(interval time.Duration, url string, parser Parser) *JSONap
 	return &JSONapiVolume{
 		JSONapi: &JSONapi{
 			url:      url,
-			urlRaw:   url,
 			interval: interval,
 			Parser:   parser,
 		},
@@ -399,7 +397,6 @@ type JSONapiVolume struct {
 
 func (self *JSONapiVolume) Get(ctx context.Context) (float64, error) {
 	var err error
-	self.url = web.ExpandTimeVars(self.urlRaw)
 	self.url = os.Expand(self.url, func(key string) string {
 		if os.Getenv(key) == "" {
 			err = errors.Errorf("missing required env variable in index url:%v", key)
@@ -431,7 +428,6 @@ func (self *JSONapiVolume) Get(ctx context.Context) (float64, error) {
 func NewJSONapi(interval time.Duration, url string, parser Parser) *JSONapi {
 	return &JSONapi{
 		url:      url,
-		urlRaw:   url,
 		interval: interval,
 		Parser:   parser,
 	}
@@ -471,7 +467,6 @@ type Bravenewcoin struct {
 
 func (self *Bravenewcoin) Get(ctx context.Context) (float64, error) {
 	var err error
-	self.url = web.ExpandTimeVars(self.urlRaw)
 	self.url = os.Expand(self.url, func(key string) string {
 		if os.Getenv(key) == "" {
 			err = errors.Errorf("missing required env variable in index url:%v", key)
@@ -554,14 +549,12 @@ func getBearer(apiKey string) (string, error) {
 
 type JSONapi struct {
 	url      string
-	urlRaw   string
 	interval time.Duration
 	Parser
 }
 
 func (self *JSONapi) Get(ctx context.Context) (float64, error) {
 	var err error
-	self.url = web.ExpandTimeVars(self.urlRaw)
 	self.url = os.Expand(self.url, func(key string) string {
 		if os.Getenv(key) == "" {
 			err = errors.Errorf("missing required env variable in index url:%v", key)


### PR DESCRIPTION
This removes the ExpandTimeVars functions, and instead calculates time vars conditionally for anyblock and cryptocompare. Timestamp variables are then added to the request instead of being expanded via env variables.